### PR TITLE
Enhance/3 add income to chart

### DIFF
--- a/src/algorithm/rtnFilteredNamedData.ts
+++ b/src/algorithm/rtnFilteredNamedData.ts
@@ -29,7 +29,8 @@ function rtnFilteredNamedData(props: Parser): any[] {
         /* We want to exclude all our money movement between personal accounts */
         trans.DESCR.includes("Recurring Transfer to") ||
         trans.DESCR.includes("Online Transfer Ref") ||
-        trans.DESCR.includes("Save As You Go Transfer Debit to")
+        trans.DESCR.includes("Save As You Go Transfer Debit to") ||
+        trans.DESCR.includes("Online Transfer to")
       ) {
         return false;
       }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React from "react";
 import "../styles/App.css";
-import AppView from "../views/AppView"
+import "../styles/Display.css";
+import AppView from "../views/AppView";
 
 function App() {
   return (

--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -1,10 +1,8 @@
 import {
-  // LineChart,
   ComposedChart,
   Line,
   XAxis,
   YAxis,
-  // CartesianGrid,
   Tooltip,
   Legend,
   ReferenceLine,
@@ -56,13 +54,6 @@ function Chart(props: any) {
           ? float(_allIncome)
           : largestIncomeRange;
     }
-
-    console.log(
-      "SMALL Y:",
-      smallestIncomeRange,
-      "LARGE Y: ",
-      largestIncomeRange
-    );
 
     return [smallestIncomeRange, largestIncomeRange];
   };
@@ -195,7 +186,7 @@ function Chart(props: any) {
     let total = largestIncomeRange - smallestIncomeRange;
     const posPercent = (total + smallestIncomeRange) / total;
 
-    return Math.ceil(posPercent * 100);
+    return Math.ceil(posPercent * 100) || 0;
   };
 
   return (
@@ -220,12 +211,7 @@ function Chart(props: any) {
           />
           <stop offset="100%" stopColor="#FF7F7F" stopOpacity={1} />
         </linearGradient>
-        {/* <linearGradient id="charge" x1="0" y1="-1" x2="0" y2="0">
-          <stop offset="50%" stopColor="#FF7F7F" stopOpacity={0.8} />
-          <stop offset="95%" stopColor="#FF7F7F" stopOpacity={0.1} />
-        </linearGradient> */}
       </defs>
-      {/* <CartesianGrid strokeDasharray="3 3" /> */}
       <XAxis
         dataKey="date"
         interval={"preserveStartEnd"}
@@ -237,12 +223,7 @@ function Chart(props: any) {
         position={{ x: 800, y: -150 }}
       />
       <ReferenceLine x={0} stroke="#fff" label="" />
-      <Legend
-        // margin={{ top: 10, left: 0, right: 0, bottom: 0 }}
-        verticalAlign="top"
-        align="right"
-        height={30}
-      />
+      <Legend verticalAlign="top" align="right" height={30} />
       <Area
         type="monotone"
         dataKey="INCOME"

--- a/src/components/CombinedDisplay.tsx
+++ b/src/components/CombinedDisplay.tsx
@@ -38,7 +38,7 @@ function CombinedDisplay(props: Props) {
     return who === "c"
       ? [
           {
-            descr: "Total of what each owes",
+            descr: "Total of what Camryn paid",
             value: c,
             fill: "#AEBCC4",
           },
@@ -53,7 +53,7 @@ function CombinedDisplay(props: Props) {
         ]
       : [
           {
-            descr: "Total of what each owes",
+            descr: "Total of what Kyle paid",
             value: k,
             fill: "#AEBCC4",
           },
@@ -85,8 +85,8 @@ function CombinedDisplay(props: Props) {
     position: "absolute",
     width: "50%",
     display: "inline-block",
-    marginLeft: props.name === "kyle" ? "50%" : "100%",
-    marginTop: "-75px",
+    marginLeft: props.name === "kyle" ? "50%" : "120%",
+    marginTop: "-175px",
     transitionTimingFunction: "ease",
     // border: "1px solid #fff",
     transition: "1s",
@@ -95,8 +95,8 @@ function CombinedDisplay(props: Props) {
     position: "absolute",
     width: "50%",
     display: "inline-block",
-    marginLeft: props.name === "camryn" ? "50%" : "100%",
-    marginTop: "-75px",
+    marginLeft: props.name === "camryn" ? "50%" : "120%",
+    marginTop: "-175px",
     transitionTimingFunction: "ease",
     // border: "1px solid #fff",
     transition: "1s",
@@ -132,7 +132,7 @@ function CombinedDisplay(props: Props) {
       </div>
       <span style={styleCObj}>
         <PieChart
-          width={300}
+          width={350}
           height={300}
           margin={{ top: 25, right: 0, bottom: 0, left: 40 }}
         >
@@ -166,7 +166,7 @@ function CombinedDisplay(props: Props) {
       </span>
       <span style={styleKObj}>
         <PieChart
-          width={300}
+          width={350}
           height={300}
           margin={{ top: 25, right: 0, bottom: 0, left: 40 }}
         >

--- a/src/components/CombinedDisplay.tsx
+++ b/src/components/CombinedDisplay.tsx
@@ -1,5 +1,4 @@
 import { PieChart, Pie, Legend, Tooltip } from "recharts";
-import "../styles/Display.css";
 import { tooltipProps } from "../types";
 import { returnBold, rmvExtraText } from "../utils";
 import React from "react";
@@ -107,8 +106,6 @@ function CombinedDisplay(props: Props) {
     props.name.split("")[0]
   )[1];
 
-  console.log(getPaymentAmountData.value.toFixed(2));
-
   return (
     <div className="combinedDataDisplay">
       <div className="description-title">{props.name}</div>
@@ -123,7 +120,9 @@ function CombinedDisplay(props: Props) {
           You {getPaymentAmountData.type} :
           {returnBold(
             `$${getPaymentAmountData.value.toFixed(2)}`,
-            getPaymentAmountData.fill
+            getPaymentAmountData.fill === "#008000"
+              ? "#82ca9d"
+              : getPaymentAmountData.fill
           )}
         </div>
         <div>

--- a/src/components/InfoDisplay.tsx
+++ b/src/components/InfoDisplay.tsx
@@ -1,4 +1,3 @@
-import "../styles/Display.css";
 import { rmvExtraText } from "../utils";
 import React from "react";
 

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -15,11 +15,13 @@
 }
 .custom-tooltip {
   z-index: 5;
+  position: relative;
   border: 1px solid #fff;
   color: #fff;
   background-color: #444;
   padding: 10px 20px;
   font-size: 12px;
+  width: 350px;
 }
 
 .App-header {

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -13,16 +13,9 @@
 .App {
   text-align: left;
 }
-.custom-tooltip {
-  z-index: 5;
-  position: relative;
-  border: 1px solid #fff;
-  color: #fff;
-  background-color: #444;
-  padding: 10px 20px;
-  font-size: 12px;
-  width: 350px;
-}
+/* .recharts-legend-wrapper {
+  padding-top: 33%;
+} */
 
 .App-header {
   width: 100%;

--- a/src/styles/Display.css
+++ b/src/styles/Display.css
@@ -114,9 +114,12 @@
 
 .description-title {
   text-transform: capitalize;
+  position: relative;
+  z-index: 1;
 }
 .description-text {
-  position: absolute;
+  position: relative;
+  z-index: 1;
   /* border: 1px solid #fff; */
   width: 50%;
   margin-top: 10px;

--- a/src/styles/Display.css
+++ b/src/styles/Display.css
@@ -13,6 +13,19 @@
   border: 1px solid darkgray;
 }
 
+.description-title {
+  text-transform: capitalize;
+  /* margin-top: 30px; */
+  z-index: 1;
+}
+.description-text {
+  z-index: 1;
+  /* border: 1px solid #fff; */
+  width: 50%;
+  margin-top: 10px;
+  padding: 10px 10px;
+}
+
 .priceDescr {
   /* vertical-align: middle; */
   display: inline-block;
@@ -68,11 +81,27 @@
   color: var(--nonHover);
 }
 
+.custom-tooltip {
+  z-index: 2;
+  position: relative;
+  border: 1px solid #fff;
+  color: #fff;
+  background-color: #444;
+  padding: 10px 20px;
+  font-size: 12px;
+  width: 350px;
+}
+
 .combinedDataDisplay {
   color: var(--nonHover);
+  z-index: 1;
   position: absolute;
   margin: 0 50%;
   width: 50%;
+}
+
+.recharts-tooltip-wrapper {
+  z-index: 2;
 }
 
 .clearState {
@@ -112,16 +141,6 @@
   border-right: 1px solid darkgray;
 }
 
-.description-title {
-  text-transform: capitalize;
-  position: relative;
-  z-index: 1;
-}
-.description-text {
-  position: relative;
-  z-index: 1;
-  /* border: 1px solid #fff; */
-  width: 50%;
-  margin-top: 10px;
-  padding: 10px 10px;
-}
+/* .recharts-legend-wrapper {
+  margin-top: 5px;
+} */

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,5 +1,5 @@
 body {
-  overflow-x: hidden;
+  overflow: hidden;
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
     "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -57,9 +57,22 @@ const getLargestPurchase = (data: any[], offset: number = 0): number => {
   return max;
 };
 
+/**
+ *
+ * Function to parseFloat() and toFixed(2)
+ *
+ * return adjusted float
+ */
+const float = (int: number | string): number => {
+  return typeof int === "string"
+    ? parseFloat(parseFloat(int).toFixed(2))
+    : parseFloat(int.toFixed(2));
+};
+
 export {
   rmvExtraText,
   getReadableDateFromDateObj,
   returnBold,
   getLargestPurchase,
+  float,
 };

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -8,7 +8,12 @@
  */
 
 const rmvExtraText = (text: string): string => {
-  return text.replace("Purchase authorized on", "");
+  let extras: string[] = ["Purchase authorized on", "INCOME "];
+  extras.forEach((searchValue: string) => {
+    text = text.replace(searchValue, "");
+  });
+
+  return text;
 };
 
 /**

--- a/src/views/AppView.tsx
+++ b/src/views/AppView.tsx
@@ -66,6 +66,7 @@ function AppView() {
           <ResponsiveContainer width="50%" height="100%">
             <Chart
               dates={dates}
+              dataOffset={0}
               data={rtnFilteredNamedData({
                 chargesOnly: false,
                 transferWithinAccountsRemoved: true,


### PR DESCRIPTION
Put Area chart in main chart to display income data

Should have 3 key features:
- Display incomes
- Display incomes with daily relationship to every charge (i.e Income of 1000 looses $50 every day because of charges and the chart reflects this by showing the area chart decline $50 every day)
- Should calculate transfers from `other accounts into` as income. Less of UI and more of backend deciding what is income and not ignoring.